### PR TITLE
Add option to create images with case-sensitive filesystems

### DIFF
--- a/AutoDMG.xcodeproj/project.pbxproj
+++ b/AutoDMG.xcodeproj/project.pbxproj
@@ -321,7 +321,7 @@
 				ORGANIZATIONNAME = "University of Gothenburg";
 				TargetAttributes = {
 					66EA72C817EB1585009B8350 = {
-						DevelopmentTeam = 5KQ3D3FG5H;
+						DevelopmentTeam = 3M328Q89SP;
 					};
 				};
 			};
@@ -584,11 +584,11 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Mac Developer";
-				DEVELOPMENT_TEAM = 5KQ3D3FG5H;
+				DEVELOPMENT_TEAM = 3M328Q89SP;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "AutoDMG/AutoDMG-Prefix.pch";
 				INFOPLIST_FILE = "AutoDMG/AutoDMG-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "se.gu.it.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = AutoDMG;
 				WRAPPER_EXTENSION = app;
@@ -600,11 +600,11 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Mac Developer";
-				DEVELOPMENT_TEAM = 5KQ3D3FG5H;
+				DEVELOPMENT_TEAM = 3M328Q89SP;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "AutoDMG/AutoDMG-Prefix.pch";
 				INFOPLIST_FILE = "AutoDMG/AutoDMG-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "se.gu.it.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = AutoDMG;
 				WRAPPER_EXTENSION = app;

--- a/AutoDMG/AutoDMG-Info.plist
+++ b/AutoDMG/AutoDMG-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8.1</string>
+	<string>1.8.1+tomtom</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AutoDMG/progresswatcher.py
+++ b/AutoDMG/progresswatcher.py
@@ -316,7 +316,12 @@ def installesdtodmg(args):
     pwargs = ["./installesdtodmg.sh",
               args.user,
               args.group,
-              {"hfs": "HFS+J", "apfs": "APFS"}[args.fstype],
+              {
+                "hfs": "HFS+J",
+                "cs-hfs": "Case-sensitive Journaled HFS+",
+                "apfs": "APFS",
+                "cs-apfs": "Case-sensitive APFS"
+              }[args.fstype],
               args.output,
               args.volume_name,
               args.size,
@@ -345,7 +350,7 @@ def main(argv):
     iedparser = sp.add_parser("installesdtodmg", help="Perform installation to DMG")
     iedparser.add_argument("-u", "--user", help="Change owner of DMG", required=True)
     iedparser.add_argument("-g", "--group", help="Change group of DMG", required=True)
-    iedparser.add_argument("-f", "--fstype", choices=["apfs", "hfs"], help="File system type", required=True)
+    iedparser.add_argument("-f", "--fstype", choices=["apfs", "cs-apfs", "hfs", "cs-hfs"], help="File system type", required=True)
     iedparser.add_argument("-o", "--output", help="Set output path", required=True)
     iedparser.add_argument("-t", "--template", help="Path to adtmpl", required=True)
     iedparser.add_argument("-n", "--volume-name", default="Macintosh HD", help="Set installed system's volume name.")


### PR DESCRIPTION
In addition to `apfs` and `hfs` filesystems, we can use their case-sensitive versions with `cs-apfs` and `cs-hfs`.